### PR TITLE
Add generic NationalID class and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# idnumbers-js
+
+A collection of validators and parsers for national identification numbers.
+
+## Installation
+
+```bash
+npm install idnumbers-js
+```
+
+## Usage
+
+Use the `NationalID` class to validate or parse identifiers by passing a
+two-letter ISO country code and the ID number:
+
+```javascript
+import { NationalID } from 'idnumbers-js';
+
+NationalID.validate('EG', '29001010100015'); // true
+const info = NationalID.parse('EG', '29001010100015');
+console.log(info.governorate); // '01'
+
+NationalID.validate('US', '012-12-0928'); // true
+```
+
+Alternatively, import specific country modules and call their exports
+directly:
+
+```javascript
+import { EGY, USA } from 'idnumbers-js';
+
+EGY.NationalID.validate('29001010100015');
+USA.SocialSecurityNumber.validate('012-12-0928');
+```
+
+You can also import individual modules via sub-paths:
+
+```javascript
+import { SocialSecurityNumber } from 'idnumbers-js/nationalid/usa/social_security.js';
+```
+
+Constants and utility helpers are exported from the package as well:
+
+```javascript
+import { Gender, validateRegexp } from 'idnumbers-js';
+```
+
+## Testing
+
+```bash
+npm test
+```
+

--- a/package.json
+++ b/package.json
@@ -2,6 +2,15 @@
   "name": "idnumbers-js",
   "version": "0.1.0",
   "type": "module",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./nationalid/*": "./src/nationalid/*",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "src"
+  ],
   "scripts": {
     "test": "node --test"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,119 @@
-export * as SpainDNI from './nationalid/esp/dni.js';
+import * as ALB from './nationalid/alb/identity_number.js';
+import * as ARE from './nationalid/are/emirates_id.js';
+import * as BGD from './nationalid/bgd/national_id.js';
+import * as BGDOld from './nationalid/bgd/old_national_id.js';
+import * as CHN from './nationalid/chn/resident_id.js';
+import * as DEU from './nationalid/deu/tax_id.js';
+import * as EGY from './nationalid/egy/national_id.js';
+import * as ESP from './nationalid/esp/dni.js';
+import * as FRA from './nationalid/fra/insee.js';
+import * as GBR from './nationalid/gbr/national_insurance.js';
+import * as IDN from './nationalid/idn/national_id.js';
+import * as IND from './nationalid/ind/national_id.js';
+import * as IRN from './nationalid/irn/national_id.js';
+import * as ITA from './nationalid/ita/fiscal_code.js';
+import * as LKA from './nationalid/lka/national_id.js';
+import * as LKAOld from './nationalid/lka/old_national_id.js';
+import * as MYS from './nationalid/mys/nric.js';
+import * as NGA from './nationalid/nga/national_id.js';
+import * as NPL from './nationalid/npl/national_id.js';
+import * as PAK from './nationalid/pak/national_id.js';
+import * as PHL from './nationalid/phl/phil_id.js';
+import * as THA from './nationalid/tha/national_id.js';
+import * as TUR from './nationalid/tur/national_id.js';
+import * as USA from './nationalid/usa/social_security.js';
+import * as VNM from './nationalid/vnm/national_id.js';
+
+const COUNTRY_MODULES = {
+  AL: ALB,
+  AE: ARE,
+  BD: BGD,
+  CN: CHN,
+  DE: DEU,
+  EG: EGY,
+  ES: ESP,
+  FR: FRA,
+  GB: GBR,
+  ID: IDN,
+  IN: IND,
+  IR: IRN,
+  IT: ITA,
+  LK: LKA,
+  MY: MYS,
+  NG: NGA,
+  NP: NPL,
+  PK: PAK,
+  PH: PHL,
+  TH: THA,
+  TR: TUR,
+  US: USA,
+  VN: VNM,
+};
+
+export class NationalID {
+  static _lookup(countryCode) {
+    if (typeof countryCode !== 'string') {
+      throw new TypeError('countryCode must be a string');
+    }
+    return COUNTRY_MODULES[countryCode.toUpperCase()];
+  }
+
+  static validate(countryCode, idNumber) {
+    const mod = this._lookup(countryCode);
+    if (!mod) {
+      throw new Error(`unsupported country code: ${countryCode}`);
+    }
+    if (mod.NationalID && typeof mod.NationalID.validate === 'function') {
+      return mod.NationalID.validate(idNumber);
+    }
+    if (typeof mod.validate === 'function') {
+      return mod.validate(idNumber);
+    }
+    throw new Error(`validation not supported for country code: ${countryCode}`);
+  }
+
+  static parse(countryCode, idNumber) {
+    const mod = this._lookup(countryCode);
+    if (!mod) {
+      throw new Error(`unsupported country code: ${countryCode}`);
+    }
+    if (mod.NationalID && typeof mod.NationalID.parse === 'function') {
+      return mod.NationalID.parse(idNumber);
+    }
+    if (typeof mod.parse === 'function') {
+      return mod.parse(idNumber);
+    }
+    throw new Error(`parsing not supported for country code: ${countryCode}`);
+  }
+}
+
+export {
+  ALB,
+  ARE,
+  BGD,
+  BGDOld,
+  CHN,
+  DEU,
+  EGY,
+  ESP,
+  FRA,
+  GBR,
+  IDN,
+  IND,
+  IRN,
+  ITA,
+  LKA,
+  LKAOld,
+  MYS,
+  NGA,
+  NPL,
+  PAK,
+  PHL,
+  THA,
+  TUR,
+  USA,
+  VNM,
+};
+
 export * from './nationalid/constant.js';
 export * from './nationalid/util.js';

--- a/test/nationalid_class.test.js
+++ b/test/nationalid_class.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { NationalID } from '../src/index.js';
+
+const validEgyptian = '29001010100015';
+
+test('validate and parse Egyptian ID via NationalID class', () => {
+  assert.strictEqual(NationalID.validate('EG', validEgyptian), true);
+  const info = NationalID.parse('EG', validEgyptian);
+  assert.strictEqual(info.governorate, '01');
+});
+
+test('validate US SSN via NationalID class', () => {
+  assert.strictEqual(NationalID.validate('US', '012-12-0928'), true);
+});
+


### PR DESCRIPTION
## Summary
- add NationalID class that validates and parses IDs by ISO country code
- document class-based usage and direct imports in README
- add tests for the new NationalID interface

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4422a7d308332acfb85096e0a74dc