### PR TITLE
Add Saudi Arabia national ID support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import * as NGA from './nationalid/nga/national_id.js';
 import * as NPL from './nationalid/npl/national_id.js';
 import * as PAK from './nationalid/pak/national_id.js';
 import * as PHL from './nationalid/phl/phil_id.js';
+import * as SAU from './nationalid/sau/national_id.js';
 import * as THA from './nationalid/tha/national_id.js';
 import * as TUR from './nationalid/tur/national_id.js';
 import * as USA from './nationalid/usa/social_security.js';
@@ -44,6 +45,7 @@ const COUNTRY_MODULES = {
   NP: NPL,
   PK: PAK,
   PH: PHL,
+  SA: SAU,
   TH: THA,
   TR: TUR,
   US: USA,
@@ -109,6 +111,7 @@ export {
   NPL,
   PAK,
   PHL,
+  SAU,
   THA,
   TUR,
   USA,

--- a/src/nationalid/sau/national_id.js
+++ b/src/nationalid/sau/national_id.js
@@ -1,0 +1,53 @@
+import { Citizenship } from '../constant.js';
+import { luhnDigit, validateRegexp } from '../util.js';
+
+const REGEXP = /^(?<type>[12])(?<sn>\d{8})(?<checksum>\d)$/;
+
+export class NationalID {
+  static METADATA = {
+    iso3166_alpha2: 'SA',
+    min_length: 10,
+    max_length: 10,
+    parsable: true,
+    checksum: true,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['National ID Number', 'Iqama', '\u0631\u0642\u0645 \u0627\u0644\u0647\u0648\u064a\u0629 \u0627\u0644\u0648\u0637\u0646\u064a\u0629'],
+    links: ['https://en.wikipedia.org/wiki/National_identification_number#Saudi_Arabia'],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const checksum = this.checksum(idNumber);
+    if (checksum === null || checksum !== Number(match.groups.checksum)) {
+      return null;
+    }
+    return {
+      type: match.groups.type === '1' ? Citizenship.CITIZEN : Citizenship.RESIDENT,
+      sn: match.groups.sn,
+      checksum,
+    };
+  }
+
+  static checksum(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return null;
+    }
+    const digits = idNumber
+      .slice(0, -1)
+      .split('')
+      .map((d) => Number(d));
+    return luhnDigit(digits);
+  }
+}

--- a/test/sau.test.js
+++ b/test/sau.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { NationalID } from '../src/nationalid/sau/national_id.js';
+import { Citizenship } from '../src/nationalid/constant.js';
+
+test('valid Saudi ID numbers', () => {
+  assert.strictEqual(NationalID.validate('1234567893'), true);
+  assert.strictEqual(NationalID.validate('2123456784'), true);
+});
+
+test('invalid Saudi ID numbers', () => {
+  assert.strictEqual(NationalID.validate('1234567890'), false);
+  assert.strictEqual(NationalID.validate('5234567893'), false);
+});
+
+test('parse Saudi ID', () => {
+  const info = NationalID.parse('1234567893');
+  assert.ok(info);
+  assert.strictEqual(info.type, Citizenship.CITIZEN);
+  assert.strictEqual(info.sn, '23456789');
+  assert.strictEqual(info.checksum, 3);
+});
+
+test('with regexp', () => {
+  assert.match('1234567893', NationalID.METADATA.regexp);
+});
+
+test('with metadata', () => {
+  assert.ok(NationalID.METADATA);
+});


### PR DESCRIPTION
## Summary
- add Saudi Arabia National ID validator and parser with Luhn checksum
- wire Saudi module into index exports and country lookup
- test Saudi ID validation and parsing

## Testing
- `npm test`

